### PR TITLE
Fix first image of coordinate in learning tutorial

### DIFF
--- a/main/web/tut_learn.js
+++ b/main/web/tut_learn.js
@@ -43,13 +43,13 @@ line 90 10
 line 90 90
 line 10 90
 line 10 10
-move 12 30
+move 12 28
 text "10/30"
 move 44 52
 text "50/50"
 color 833
 linewidth 2
-move 18 26
+move 18 34
 line 50 50
 
 + The drawing area is 100 times 100 units. The origin is top left. The first value (the X coordinate) is the distance from the left edge, the second value (the Y coordinate) is the distance from the top edge.


### PR DESCRIPTION
Fix first image of coordinate in learning tutorial. Image contains red
line labelled as starting at 10/30, however it is starting at 10/20.
Move line to start at 10/30 so that descriptive text corresponds. Update
label in chart for better alignment.

Code has been manually tested as part of the tutorial.