### PR TITLE
Added strbytes function

### DIFF
--- a/main/kafunc.h
+++ b/main/kafunc.h
@@ -1391,15 +1391,11 @@ S ARR op_strbytes(ND* nd) {
         int sym_len = ulen(s_p[cur_str_loc]);
         int cp = 0;
 
-        if (sym_len == 1) {
-            cp = s_p[cur_str_loc];
-        } else if (sym_len == 2) {
-            cp = s_p[cur_str_loc] & 0x1f;
-        } else if (sym_len == 3) {
-            cp = s_p[cur_str_loc] & 0x0f;
-        } else if (sym_len == 4) {
-            cp = s_p[cur_str_loc] & 0x07;
-        } else {
+        if 		(sym_len == 1) cp = s_p[cur_str_loc];
+        else if (sym_len == 2) cp = s_p[cur_str_loc] & 0x1f;
+        else if (sym_len == 3) cp = s_p[cur_str_loc] & 0x0f;
+        else if (sym_len == 4) cp = s_p[cur_str_loc] & 0x07;
+        else {
             printf("ERROR: unknown symbol_len returned from ulen in kafunc op_strbytes\n");
             return res;
         }

--- a/main/kaparse.h
+++ b/main/kaparse.h
@@ -1179,7 +1179,11 @@ S ND* parse_numarrex(void) {
 		csb_tok_nt();
 		cs_spc();
 		ex->le = parse_strarrex();;
-	}
+	} else if (tok == t_name && strcmp(tval, "strbytes") == 0) {
+        ex->arrf = op_strbytes;
+        csb_tok_spc_nt();
+        ex->le = parse_strex();
+    }
 	else error("array");
 	return ex;
 }


### PR DESCRIPTION
This function converts a string into a byte array, this can be useful when you need the actual bytes instead of  the string values like in advent of code 2017 for the knot hash algorithm (day 10 and 14).

example usage:

```sh
s$ = "Umlaute: äöü"

bytes[] = strbytes s$

print bytes[]
```

![strbytes-example](https://github.com/chkas/easylang/assets/91525610/53729cd8-0757-49f5-ab0a-269a0ae505e5)